### PR TITLE
Adds Functionality To Read MFA Token Values From The Command Line

### DIFF
--- a/pkg/provider/pingfed/example/token.html
+++ b/pkg/provider/pingfed/example/token.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>Token</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <meta http-equiv="x-ua-compatible" content="IE=edge">
+</head>
+<body>
+
+<div class="ping-container ping-signin login-template" style="padding-top:0px;padding-bottom:0px;min-height:0;">
+
+  <!--
+  if there is a logo present in the 'company-logo' container,
+  then 'has-logo' class should be added to 'ping-header' container.
+  -->
+  <div class="ping-header">
+    Token Sign On
+  </div>
+  <!-- .ping-header -->
+
+  <div class="ping-body-container" style="margin-bottom:0px">
+
+    <div>
+      <form method="POST" action="/token" autocomplete="off">
+
+        <div class="ping-messages">
+
+
+        </div>
+
+
+        <div class="ping-input-label">
+          Username
+        </div>
+        <div class="ping-input-container">
+          <input id="username" type="text" size="36" name="pf.username" value="user123" disabled="disabled" autocorrect="off" autocapitalize="off" onkeypress="return postOnReturn(event)"><!---->
+          <div class="place-bottom type-alert tooltip-text" id="username-text">
+            <div class="icon">!</div>
+            Please fill out this field.
+          </div>
+        </div>
+
+        <div class="ping-input-label">
+          Token code
+        </div>
+        <div class="ping-input-container password-container">
+          <input id="password" type="password" size="36" name="pf.pass" onkeypress="return postOnReturn(event)">
+          <div class="place-bottom type-alert tooltip-text" id="password-text">
+            <div class="icon">!</div>
+            Please fill out this field.
+          </div>
+        </div>
+
+        <div class="ping-buttons">
+          <input type="hidden" name="pf.ok" value="">
+          <input type="hidden" name="pf.cancel" value="">
+
+          <a onclick="postOk();" class="ping-button normal allow" title="Sign On">
+            Sign On
+          </a>
+        </div><!-- .ping-buttons -->
+      </form>
+    </div><!-- .ping-body// blank div -->
+
+  </div><!-- .ping-body-container -->
+
+</div><!-- .ping-container -->
+
+</body></html>

--- a/pkg/provider/pingfed/pingfed.go
+++ b/pkg/provider/pingfed/pingfed.go
@@ -267,7 +267,14 @@ func (ac *Client) handleToken(ctx context.Context, doc *goquery.Document) (conte
 		return ctx, nil, errors.Wrap(err, "error extracting login form")
 	}
 
-	token := prompter.Password("Enter Token Code (PIN + Token / Passcode for RSA)")
+	// Pull MFA token from command line if specified
+	token := loginDetails.MFAToken
+
+	// Request token
+	if loginDetails.MFAToken == "" || mfaAttempt > 0 {
+		token = prompter.Password("Enter Token Code (PIN + Token / Passcode for RSA)")
+	}
+	mfaAttempt++
 
 	// Make sure a token value was provided
 	if token == "" {

--- a/pkg/provider/pingfed/pingfed_test.go
+++ b/pkg/provider/pingfed/pingfed_test.go
@@ -94,6 +94,8 @@ func TestHandleLogin(t *testing.T) {
 }
 
 func TestHandleOTP(t *testing.T) {
+	mfaAttempt = 0
+
 	pr := &mocks.Prompter{}
 	prompter.SetPrompter(pr)
 	pr.Mock.On("Password", "Enter passcode").Return("5309")
@@ -123,6 +125,8 @@ func TestHandleOTP(t *testing.T) {
 }
 
 func TestHandleToken(t *testing.T) {
+	mfaAttempt = 0
+
 	data, err := ioutil.ReadFile("example/token.html")
 	require.Nil(t, err)
 
@@ -149,6 +153,8 @@ func TestHandleToken(t *testing.T) {
 }
 
 func TestHandleTokenWithStdin(t *testing.T) {
+	mfaAttempt = 0
+
 	pr := &mocks.Prompter{}
 	prompter.SetPrompter(pr)
 	pr.Mock.On("Password", "Enter Token Code (PIN + Token / Passcode for RSA)").Return("1337")
@@ -178,6 +184,8 @@ func TestHandleTokenWithStdin(t *testing.T) {
 }
 
 func TestHandleOTPWithArgument(t *testing.T) {
+	mfaAttempt = 0
+
 	data, err := ioutil.ReadFile("example/otp.html")
 	require.Nil(t, err)
 


### PR DESCRIPTION
Closes #67 

This PR will allow a user to pass in a token value from the command line for the PingFed provider. Accompanying tests for the function have also been added.