### PR TITLE
amazonaws.cn URL handling

### DIFF
--- a/pkg/provider/pingfed/pingfed.go
+++ b/pkg/provider/pingfed/pingfed.go
@@ -726,6 +726,7 @@ func docIsFormResume(doc *goquery.Document) bool {
 
 func docIsFormRedirectToAWS(doc *goquery.Document) bool {
 	return doc.Find("form[action=\"https://signin.aws.amazon.com/saml\"]").Size() == 1 ||
+		doc.Find("form[action=\"https://signin.amazonaws.cn/saml\"]").Size() == 1 ||
 		doc.Find("form[action=\"https://signin.amazonaws-us-gov.com/saml\"]").Size() == 1
 }
 


### PR DESCRIPTION
China resources use a different set of URLs, which confuses gossamer3. This patch fixes both login and console commands with AWS China resources. There is a caveat though: you have to provide a region, otherwise auth won't work.